### PR TITLE
fix assertion error on empty slug

### DIFF
--- a/autoslug/fields.py
+++ b/autoslug/fields.py
@@ -270,9 +270,10 @@ class AutoSlugField(SlugField):
                 print('Failed to populate slug %s.%s from %s' % \
                       (instance._meta.object_name, self.name, self.populate_from))
 
+        slug = None
         if value:
             slug = self.slugify(value)
-        else:
+        if not slug:
             slug = None
 
             if not self.blank:

--- a/autoslug/tests/tests.py
+++ b/autoslug/tests/tests.py
@@ -139,6 +139,10 @@ class AutoSlugFieldTestCase(TestCase):
         assert a.slug is not None
         assert a.slug == ''
 
+    def test_empty_slugify(self):
+        a = ModelWithUniqueSlug.objects.create(name='?')
+        assert a.slug
+
     def test_callable(self):
         a = ModelWithCallable.objects.create(name='larch')
         assert a.slug == u'the-larch'


### PR DESCRIPTION
This fixes the problem with generating the slug from strings like '?'
Unfortunately, this wasn't merged to django-autoslug.

Original pull request: https://github.com/justinmayer/django-autoslug/pull/18/files